### PR TITLE
Actually unsubscribe from channel

### DIFF
--- a/lib/ember-pusher/controller.js
+++ b/lib/ember-pusher/controller.js
@@ -131,7 +131,7 @@ var Controller = Ember.Controller.extend({
     delete bindings[channelName].eventBindings[targetId];
 
     // Unsubscribe from the channel if this is the last thing listening
-    if(bindings[channelName].eventBindings.length === 0) {
+    if(Object.keys(bindings[channelName].eventBindings).length === 0) {
       pusher.unsubscribe(channelName);
       delete bindings[channelName];
       return true;


### PR DESCRIPTION
Actually unsubscribe from channel when unwire and if this is the last controller listening.

Was not working since `eventBindings` is an object and objects do not have length property.
