### PR TITLE
Added guard to prevent from calling set on a destroyed controller

### DIFF
--- a/lib/ember-pusher/controller.js
+++ b/lib/ember-pusher/controller.js
@@ -154,10 +154,12 @@ var Controller = Ember.Controller.extend({
   }.property('isDisconnected'),
 
   _didConnect: function() {
+    if (this.isDestroyed) { return; }
     this.set('isDisconnected', false);
   },
 
   _didDisconnect: function() {
+    if (this.isDestroyed) { return; }
     this.set('isDisconnected', true);
   }
 


### PR DESCRIPTION
I saw these errors appear in my debugger after updating to ember 1.13.3. Looks like we need to gaurd against calling set on a destroyed on controller

<img width="941" alt="screen shot 2015-07-15 at 2 07 43 pm" src="https://cloud.githubusercontent.com/assets/61075/8707075/8aa254fc-2b01-11e5-8563-1d5afdc7df18.png">
