### PR TITLE
Replace contains for includes, since contains has been deprecated

### DIFF
--- a/addon/services/pusher.js
+++ b/addon/services/pusher.js
@@ -179,7 +179,7 @@ export default Ember.Service.extend({
     let index = eventBindings.length;
     while (index--){
       let binding = eventBindings[index];
-      if(eventsToUnwire && !eventsToUnwire.contains(binding.eventName)) {
+      if(eventsToUnwire && !eventsToUnwire.includes(binding.eventName)) {
         return;
       }
       channel.unbind(binding.eventName, binding.handler);


### PR DESCRIPTION
This PR replaces the use of `.contains` for `.includes` since `.contains` is no longer a method on the array in the latest versions of Ember.

https://www.emberjs.com/deprecations/v2.x/#toc_ember-runtime-enumerable-contains